### PR TITLE
Compose after ExamineComposer

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build status](https://img.shields.io/appveyor/ci/skttl/our-umbraco-fulltextsearch.svg)](https://ci.appveyor.com/project/skttl/our-umbraco-fulltextsearch)
 [![NuGet release](https://img.shields.io/nuget/v/Our.Umbraco.FullTextSearch.svg)](https://www.nuget.org/packages/Our.Umbraco.FullTextSearch)
-[![Our Umbraco project page](https://img.shields.io/badge/our-umbraco-orange.svg)](https://our.umbraco.org/projects/backoffice-extensions/full-text-search-8)
+[![Our Umbraco project page](https://img.shields.io/badge/our-umbraco-orange.svg)](https://our.umbraco.com/packages/website-utilities/full-text-search-8/)
 
 Full Text Search is a fast, powerful and easy to setup search solution for Umbraco sites.
 
@@ -21,7 +21,7 @@ Full Text Search can be installed from either Our Umbraco package repository, Nu
 
 To install from Our Umbraco, please download the package from:
 
-> [https://our.umbraco.org/projects/backoffice-extensions/full-text-search-8](https://our.umbraco.org/projects/backoffice-extensions/full-text-search-8)
+> [https://our.umbraco.com/packages/website-utilities/full-text-search-8/](https://our.umbraco.com/packages/website-utilities/full-text-search-8/)
 
 #### NuGet package repository
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ version: 0.1.0.{build}
 # UMBRACO_PACKAGE_PRERELEASE_SUFFIX if a rtm release build this should be blank, otherwise if empty will default to alpha
 # example UMBRACO_PACKAGE_PRERELEASE_SUFFIX=beta
 init:
-  - set UMBRACO_PACKAGE_PRERELEASE_SUFFIX=beta
+  - set UMBRACO_PACKAGE_PRERELEASE_SUFFIX=
 
 cache:
   - src\packages -> **\packages.config  # preserve "packages" directory in the root of build folder but will reset it if packages.config is modified

--- a/src/Our.Umbraco.FullTextSearch/Components/AddFullTextItemsToIndex.cs
+++ b/src/Our.Umbraco.FullTextSearch/Components/AddFullTextItemsToIndex.cs
@@ -6,9 +6,11 @@ using System.Linq;
 using Umbraco.Core.Composing;
 using Umbraco.Core.Logging;
 using Umbraco.Examine;
+using Umbraco.Web.Search;
 
 namespace Our.Umbraco.FullTextSearch.Components
 {
+    [ComposeAfter(typeof(ExamineComposer))]
     public class AddFullTextItemsToIndexComposer : ComponentComposer<AddFullTextItemsToIndex> { }
     public class AddFullTextItemsToIndex : IComponent
     {


### PR DESCRIPTION
Hi Soren,

Nice package! I've seen a few issue with accessing the External index in a Component that is registered using `ComponentComposer`. This issue is that it is possible for the custom component to run before the core Examine Composer.

By using `ComposeAfter` attribute you can specify this runs after the Examine composer, meaning it should reduce the changes of the External Index not existing.

Thanks

Nik