### PR TITLE
Convert fuzzy multipliers to invariant culture

### DIFF
--- a/src/Our.Umbraco.FullTextSearch/Services/SearchService.cs
+++ b/src/Our.Umbraco.FullTextSearch/Services/SearchService.cs
@@ -233,7 +233,7 @@ namespace Our.Umbraco.FullTextSearch.Services
                     var fuzzyLocal = property.FuzzyMultiplier;
                     if (fuzzyLocal < 1.0 && fuzzyLocal > 0.0)
                     {
-                        fuzzyString = "~" + fuzzyLocal;
+                        fuzzyString = "~" + fuzzyLocal.ToString(CultureInfo.InvariantCulture);
                     }
                 }
             }
@@ -254,7 +254,7 @@ namespace Our.Umbraco.FullTextSearch.Services
                     var fuzzyLocal = property.FuzzyMultiplier;
                     if (fuzzyLocal < 1.0 && fuzzyLocal > 0.0)
                     {
-                        fuzzyString = "~" + fuzzyLocal;
+                        fuzzyString = "~" + fuzzyLocal.ToString(CultureInfo.InvariantCulture);
                     }
                 }
             }


### PR DESCRIPTION
Fixes #25 

When using cultures using comma in stead of a dot before the decimals, the lucene query is wrongly added with eg. `^0,8` as the fuzzyness modifier.

This fix converts the fuzzyness value to invariant culture string to prevent this.